### PR TITLE
The application will be able to show the correct value/unit

### DIFF
--- a/MyWeight/Screens/List/MassViewModel.swift
+++ b/MyWeight/Screens/List/MassViewModel.swift
@@ -57,6 +57,7 @@ extension MassViewModel {
 
     static let massFormatter: MeasurementFormatter = {
         let massFormatter = MeasurementFormatter()
+        massFormatter.unitOptions = MeasurementFormatter.UnitOptions.providedUnit;
         massFormatter.numberFormatter.minimumFractionDigits = 1
         massFormatter.numberFormatter.maximumFractionDigits = 1
 


### PR DESCRIPTION
By setting the `MeasurementFormatter` to use the unit from the passed value, the application will be able to show the correct value.