### PR TITLE
Remove double 'brew updade' command from setup

### DIFF
--- a/rakelib/setup-project.rake
+++ b/rakelib/setup-project.rake
@@ -57,7 +57,7 @@ end
 # -- brew
 
 def brew_update
-  sh 'brew update || brew update'
+  sh 'brew update || brew upgrade'
 end
 
 def brew_install( formula )


### PR DESCRIPTION
I don't see why the `brew_update` command is on the setup rake file, but I believe that the double `brew update` instruction may be a bug.