### PR TITLE
Mass picker improvements

### DIFF
--- a/MyWeight.xcodeproj/project.pbxproj
+++ b/MyWeight.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = "Diogo Tridapalli";
 				TargetAttributes = {
 					D97F43FF1CAB5E50000F4E12 = {

--- a/MyWeight.xcodeproj/xcshareddata/xcschemes/MyWeight.xcscheme
+++ b/MyWeight.xcodeproj/xcshareddata/xcschemes/MyWeight.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MyWeight/Views/MassPicker.swift
+++ b/MyWeight/Views/MassPicker.swift
@@ -218,7 +218,7 @@ extension MassPicker {
         case .value:
             width = style.grid * 20
         case .unit:
-            width = style.grid * 8
+            width = style.grid * 11
         }
 
         return width

--- a/MyWeight/Views/MassPicker.swift
+++ b/MyWeight/Views/MassPicker.swift
@@ -97,6 +97,14 @@ public class MassPicker: UIView {
                          inComponent: Components.unit.rawValue,
                          animated: true)
     }
+
+    let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 1
+        formatter.maximumFractionDigits = 1
+
+        return formatter
+    }()
 }
 
 extension MassPicker: UIPickerViewDataSource, UIPickerViewDelegate {
@@ -159,7 +167,8 @@ extension MassPicker: UIPickerViewDataSource, UIPickerViewDelegate {
 
         switch aComponent {
         case .value:
-            text = String(Value.value(for: row))
+            let value = Value.value(for: row)
+            text = numberFormatter.string(from: value as NSNumber) ?? String(value)
         case .unit:
             guard let unit = DisplayUnit(rawValue: row) else {
                 Log.debug("This should not happen")


### PR DESCRIPTION
- Increased unit width (it was cropping in iPhone 5)
- Added a formatter to display numbers with right separator