### PR TITLE
Focus on the interface picker when the List View appears

### DIFF
--- a/Watch Extension/AddInterfaceController/AddInterfaceController.swift
+++ b/Watch Extension/AddInterfaceController/AddInterfaceController.swift
@@ -22,8 +22,6 @@ class AddInterfaceController: WKInterfaceController {
 
     override func awake(withContext context: Any?) {
         super.awake(withContext: context)
-        interfacePicker.focus()
-        
         updateView(with: viewModel)
 
         if let mass = context as? Mass {
@@ -36,6 +34,11 @@ class AddInterfaceController: WKInterfaceController {
                 self?.populatePicker(with: mass.value)
             }
         }
+    }
+    
+    override func didAppear() {
+        super.didAppear()
+        interfacePicker.focus()
     }
 
     func updateView(with viewModel: AddInterfaceControllerViewModel) {


### PR DESCRIPTION
Fixes the annoying bug that the interface picker is not focused after you tap `Add` on the Watch.