### PR TITLE
Observe authorization changes in list screen

### DIFF
--- a/HealthService/Sources/HealthService/AuthorizationStatusPublisher.swift
+++ b/HealthService/Sources/HealthService/AuthorizationStatusPublisher.swift
@@ -1,0 +1,134 @@
+//
+//  AuthorizationStatusPublisher.swift
+//  
+//
+//  Created by Diogo Tridapalli on 19/11/22.
+//
+
+#if os(iOS)
+
+import Combine
+import Foundation
+import HealthKit
+import UIKit
+
+struct AuthorizationStatusPublisher: Publisher {
+    typealias Output = HealthRepositoryAuthorizationStatus
+    typealias Failure = Never
+
+    let dataKind: DataKind
+    let authorizationMightHadChangedPublisher: AnyPublisher<DataKind, Never>
+    let healthRepository: HealthRepository
+    let notificationCenter: NotificationCenter
+
+    func receive<S>(subscriber: S) where S : Subscriber, Self.Failure == S.Failure, Self.Output == S.Input {
+        let subscription = AuthorizationSubscription(
+            subscriber: subscriber,
+            dataKind: dataKind,
+            authorizationMightHadChangedPublisher: authorizationMightHadChangedPublisher,
+            healthRepository: healthRepository,
+            notificationCenter: notificationCenter
+        )
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+private final class AuthorizationSubscription<S: Subscriber>: Subscription
+    where S.Input == HealthRepositoryAuthorizationStatus, S.Failure == Never
+{
+    private var subscriber: S?
+    private var requested: Subscribers.Demand = .none
+
+    private let dataKind: DataKind
+    private let authorizationMightHadChangedPublisher: AnyPublisher<DataKind, Never>
+    private let healthRepository: HealthRepository
+    private let notificationCenter: NotificationCenter
+
+    private let subscriberQueue = DispatchQueue.main
+    private var updateStatusSubject = PassthroughSubject<Void, Never>()
+    @Published private var currentStatus = HealthRepositoryAuthorizationStatus.notDetermined
+    private var cancellables = [AnyCancellable]()
+
+
+    init(subscriber: S,
+         dataKind: DataKind,
+         authorizationMightHadChangedPublisher: AnyPublisher<DataKind, Never>,
+         healthRepository: HealthRepository,
+         notificationCenter: NotificationCenter
+    ) {
+        self.subscriber = subscriber
+        self.dataKind = dataKind
+        self.authorizationMightHadChangedPublisher = authorizationMightHadChangedPublisher
+        self.healthRepository = healthRepository
+        self.notificationCenter = notificationCenter
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        cancellables.removeAll()
+        requested += demand
+
+        guard requested > 0 else {
+            subscriberQueue.async {
+                self.subscriber?.receive(completion: .finished)
+            }
+            cleanUp()
+            return
+        }
+
+        updateStatusSubject
+            .prepend(())
+            .sink { [weak self] _ in
+                guard let me = self else {
+                    return
+                }
+                me.currentStatus = me.healthRepository.authorizationStatus(for: me.dataKind)
+            }.store(in: &cancellables)
+
+        notificationCenter
+            .publisher(for: UIApplication.didBecomeActiveNotification)
+            .map({ _ in () })
+            .subscribe(updateStatusSubject)
+            .store(in: &cancellables)
+
+        authorizationMightHadChangedPublisher
+            .filter { [dataKind] kind in
+                kind == dataKind
+            }
+            .map({ _ in () })
+            .subscribe(updateStatusSubject)
+            .store(in: &cancellables)
+
+        $currentStatus
+            .removeDuplicates()
+            .receive(on: subscriberQueue)
+            .sink { [weak self] status in
+                guard let me = self else {
+                    return
+                }
+
+                guard let subscriber = me.subscriber, me.requested > 0 else {
+                    me.complete()
+                    return
+                }
+
+                me.requested += subscriber.receive(status)
+                me.requested -= 1
+            }.store(in: &cancellables)
+    }
+
+    func cancel() {
+        cleanUp()
+    }
+
+    private func complete() {
+        subscriber?.receive(completion: .finished)
+        cleanUp()
+    }
+
+    private func cleanUp() {
+        cancellables.removeAll()
+        subscriber = nil
+    }
+}
+
+#endif

--- a/HealthService/Sources/HealthService/HealthRepository.swift
+++ b/HealthService/Sources/HealthService/HealthRepository.swift
@@ -17,6 +17,7 @@ public protocol HealthRepository {
     func requestAuthorization(for kind: DataKind) -> AnyPublisher<Void, HealthRepositoryError>
     func observeChanges(in kind: DataKind) -> AnyPublisher<Void, HealthRepositoryError>
 #if os(iOS)
+    func authorizationStatusPublisher(for kind: DataKind) -> AnyPublisher<HealthRepositoryAuthorizationStatus, Never>
     func requestAuthorizationForExtension(for kind: DataKind) -> AnyPublisher<Void, HealthRepositoryError>
 #endif
 }

--- a/MyWeight/Extensions/Publisher+Extensions.swift
+++ b/MyWeight/Extensions/Publisher+Extensions.swift
@@ -10,6 +10,22 @@ import Combine
 import Foundation
 
 extension Publisher {
+    func catchFailureAndLog(completeImmediately: Bool = true, functionName: String = #function, fileName: String = #file,
+                            lineNumber: Int = #line) -> AnyPublisher<Output, Never> {
+        self.catch { error -> Empty<Output, Never> in
+            Log.error(error, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+            return Empty(completeImmediately: completeImmediately)
+        }.eraseToAnyPublisher()
+    }
+
+    func catchFailureLogAndReplace(with element: Output, functionName: String = #function,
+                                   fileName: String = #file, lineNumber: Int = #line) -> AnyPublisher<Output, Never> {
+        self.catch { error -> Just<Output> in
+            Log.error(error, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+            return Just(element)
+        }.eraseToAnyPublisher()
+    }
+
     func sink<T: AnyObject>(weak object: T,
                             receiveCompletion: ((T, Subscribers.Completion<Self.Failure>) -> Void)? = nil,
                             receiveValue: ((T, Self.Output) -> Void)? = nil) -> AnyCancellable {

--- a/MyWeightTests/FakeHealthRepository.swift
+++ b/MyWeightTests/FakeHealthRepository.swift
@@ -71,6 +71,15 @@ final class FakeHealthRepository: HealthRepository {
         return observeChangesResponse.asAnyPublisher()
     }
 
+    var authorizationStatusPublisherResponse: Result<HealthRepositoryAuthorizationStatus, Never> = .success(.notDetermined)
+    private(set) var authorizationStatusPublisherCalls = 0
+    private(set) var authorizationStatusPublisherKindInput = [DataKind]()
+    func authorizationStatusPublisher(for kind: DataKind) -> AnyPublisher<HealthRepositoryAuthorizationStatus, Never> {
+        authorizationStatusPublisherKindInput.append(kind)
+        authorizationStatusPublisherCalls += 1
+        return authorizationStatusPublisherResponse.asAnyPublisher()
+    }
+
     var requestAuthorizationForExtensionResponse: Result<Void, HealthRepositoryError> = .success(())
     private(set) var requestAuthorizationForExtensionCalls = 0
     private(set) var requestAuthorizationForExtensionKindInput = [DataKind]()


### PR DESCRIPTION
The mass observable was completing due to lack of authorization status.
Now we're observing authorization changes and starting to observa again on each change.